### PR TITLE
issue#36 fixed comments out of screen

### DIFF
--- a/Anonymouse/Anonymouse/AnonymouseTableViewCell.swift
+++ b/Anonymouse/Anonymouse/AnonymouseTableViewCell.swift
@@ -136,7 +136,8 @@ class AnonymouseTableViewCell : UITableViewCell {
     }
     
     func createMessageLabel(withNumberOfLines numberOfLines: Int) {
-        messageLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 340.0, height: CGFloat.greatestFiniteMagnitude))
+        let messageWidth = UIScreen.main.bounds.width * 0.9
+        messageLabel = UILabel(frame: CGRect(x: 0, y: 0, width: messageWidth, height: CGFloat.greatestFiniteMagnitude))
         messageLabel!.numberOfLines = numberOfLines
         messageLabel!.lineBreakMode = NSLineBreakMode.byTruncatingTail
         


### PR DESCRIPTION
Changed the hard-coded message width to accomodate to screen width
Before the change:
<img width="320" alt="screen shot 2016-11-10 at 4 50 00 pm" src="https://cloud.githubusercontent.com/assets/15572885/20195840/1b008db6-a766-11e6-9cb3-bac35fbb9ea4.png">
After the change:
<img width="320" alt="screen shot 2016-11-10 at 4 49 31 pm" src="https://cloud.githubusercontent.com/assets/15572885/20195846/20a0e860-a766-11e6-80bd-52ea1d914cb0.png">
