### PR TITLE
issue#39 Cap stored number of messages

### DIFF
--- a/Anonymouse/Anonymouse/AnonymouseConnectivityController.swift
+++ b/Anonymouse/Anonymouse/AnonymouseConnectivityController.swift
@@ -191,6 +191,9 @@ class AnonymouseConnectivityController : NSObject, MCNearbyServiceAdvertiserDele
             let messageHashes: [String] = dataController.fetchMessageHashes()
             //Add the message if we don't have it already
             if !messageHashes.contains(message.messageHash) {
+                while self.dataController.getSize() > 1000 {
+                    self.dataController.deleteLastMessage()
+                }
                 self.dataController.addMessage(message.text!, date: message.date!, user: message.user!)
             }
         }
@@ -201,6 +204,9 @@ class AnonymouseConnectivityController : NSObject, MCNearbyServiceAdvertiserDele
             for message in messageArray {
                 //Add each message if we don't have it
                 if !messageHashes.contains(message.messageHash) {
+                    while self.dataController.getSize() > 1000 {
+                       self.dataController.deleteLastMessage()
+                    }
                     self.dataController.addMessage(message.text!, date: message.date!, user: message.user!)
                 }
             }

--- a/Anonymouse/Anonymouse/AnonymouseDataController.swift
+++ b/Anonymouse/Anonymouse/AnonymouseDataController.swift
@@ -178,4 +178,14 @@ class AnonymouseDataController: NSObject {
         
         self.saveContext()
     }
+    
+    func getSize() -> Int {
+        //Get how many messages are in the core
+        return fetchObjects(withKey: "date", ascending: true).count
+    }
+    
+    func deleteLastMessage() {
+        // delete the last(oldest) message in core data
+        self.managedObjectContext.delete(self.fetchObjects(withKey: "date", ascending: false).last!)
+    }
 }

--- a/Anonymouse/Anonymouse/AnonymouseTableViewCell.swift
+++ b/Anonymouse/Anonymouse/AnonymouseTableViewCell.swift
@@ -136,7 +136,7 @@ class AnonymouseTableViewCell : UITableViewCell {
     }
     
     func createMessageLabel(withNumberOfLines numberOfLines: Int) {
-        let messageWidth = UIScreen.main.bounds.width * 0.9
+        let messageWidth: CGFloat = UIScreen.main.bounds.width * 0.9
         messageLabel = UILabel(frame: CGRect(x: 0, y: 0, width: messageWidth, height: CGFloat.greatestFiniteMagnitude))
         messageLabel!.numberOfLines = numberOfLines
         messageLabel!.lineBreakMode = NSLineBreakMode.byTruncatingTail


### PR DESCRIPTION
cap the max number of messages to 1000, tested with my phone.
Here I only delete the message on core data if number of messages exceed the cap. The reason why I didn't delete it in hashed message list is that a user should not receive the same message he/she has received a long time ago so we should keep the hash.
Correct me if I am wrong.